### PR TITLE
Implement format

### DIFF
--- a/lib/format.ex
+++ b/lib/format.ex
@@ -15,7 +15,7 @@ defmodule Momento.Format do
       "7-1-16"
   """
 
-  @tokens ~r/YYYY|YY?|MMMM|MMM|MM?M?M?|DD?D?D?|HH?|mm?|ss?|X|x/
+  @tokens ~r/YYYY|YY?|MMMM|MMM|MM?M?M?|Do|DD?D?D?|HH?|mm?|ss?|X|x/
 
   @spec format(DateTime.t, String.t) :: String.t
   # An implementation of the Moment.js formats listed here: http://momentjs.com/docs/#/displaying/format/
@@ -66,7 +66,7 @@ defmodule Momento.Format do
           "DD" -> datetime.day |> Integer.to_string |> String.rjust(2, ?0)
 
           # TODO: 1st 2nd ... 30th 31st
-          # "Do" -> datetime.day |> Integer.to_string
+          "Do" -> datetime.day |> get_ordinal_form
 
           # 1 2 ... 30 31
           "D" -> datetime.day |> Integer.to_string
@@ -232,6 +232,23 @@ defmodule Momento.Format do
       :MMM -> String.slice(month_name, 0..2)
        _ -> month_name
     end
+  end
+
+  defp get_ordinal_form(number) do
+    number_rem_hundred = rem(number, 100)
+    ordinal_form = 
+      if number_rem_hundred == 11 || number_rem_hundred == 12 || number_rem_hundred == 13 do
+        "th"
+      else
+        number_rem_ten = rem(number, 10)
+          cond do
+            number_rem_ten == 1 -> "st"
+            number_rem_ten == 2 -> "nd"
+            number_rem_ten == 3 -> "rd"
+            true -> "th"
+          end      
+      end
+    Integer.to_string(number) <> ordinal_form 
   end
 
 end

--- a/lib/format.ex
+++ b/lib/format.ex
@@ -15,7 +15,7 @@ defmodule Momento.Format do
       "7-1-16"
   """
 
-  @tokens ~r/YYYY|YY?|MMMM|MMM|MM?M?M?|Do|DD?D?D?|HH?|mm?|ss?|X|x/
+  @tokens ~r/YYYY|YY?|MM?M?M?|Do|DD?D?D?|HH?|mm?|ss?|X|x/
 
   @spec format(DateTime.t, String.t) :: String.t
   # An implementation of the Moment.js formats listed here: http://momentjs.com/docs/#/displaying/format/

--- a/lib/format.ex
+++ b/lib/format.ex
@@ -15,7 +15,7 @@ defmodule Momento.Format do
       "7-1-16"
   """
 
-  @tokens ~r/YYYY|YY?|MM?M?M?|DD?D?D?|HH?|mm?|ss?|X|x/
+  @tokens ~r/YYYY|YY?|MMMM|MMM|MM?M?M?|DD?D?D?|HH?|mm?|ss?|X|x/
 
   @spec format(DateTime.t, String.t) :: String.t
   # An implementation of the Moment.js formats listed here: http://momentjs.com/docs/#/displaying/format/
@@ -39,10 +39,10 @@ defmodule Momento.Format do
           # "Y" -> datetime.year |> Integer.to_string)
 
           # TODO: January February ... November December
-          # "MMMM" -> datetime.month |> Integer.to_string
+          "MMMM" -> datetime.month |> get_month_name
 
           # TODO: Jan Feb ... Nov Dec
-          # "MMM" -> datetime.month |> Integer.to_string
+          "MMM" -> datetime.month |> get_month_name(:MMM)
 
           # 01 02 ... 11 12
           "MM" -> datetime.month |> Integer.to_string |> String.rjust(2, ?0)
@@ -225,4 +225,13 @@ defmodule Momento.Format do
       # Recombine the pieces
       |> Enum.join
   end
+
+  defp get_month_name(month_number, token \\ :MMMM) do
+    month_name = elem({"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"}, month_number-1)
+    case token do
+      :MMM -> String.slice(month_name, 0..2)
+       _ -> month_name
+    end
+  end
+
 end

--- a/spec/format_spec.exs
+++ b/spec/format_spec.exs
@@ -25,11 +25,33 @@ defmodule FormatSpec do
       end
 
       it "should replace the MMMM token with the full month name" do
-        shared.datetime |> Momento.format("MMMM") |> expect |> to(eql "May")
+        %DateTime{Momento.date! | month: 1} |> Momento.format("MMMM") |> expect |> to(eql "January")
+        %DateTime{Momento.date! | month: 2} |> Momento.format("MMMM") |> expect |> to(eql "February")
+        %DateTime{Momento.date! | month: 3} |> Momento.format("MMMM") |> expect |> to(eql "March")
+        %DateTime{Momento.date! | month: 4} |> Momento.format("MMMM") |> expect |> to(eql "April")
+        %DateTime{Momento.date! | month: 5} |> Momento.format("MMMM") |> expect |> to(eql "May")
+        %DateTime{Momento.date! | month: 6} |> Momento.format("MMMM") |> expect |> to(eql "June")
+        %DateTime{Momento.date! | month: 7} |> Momento.format("MMMM") |> expect |> to(eql "July")
+        %DateTime{Momento.date! | month: 8} |> Momento.format("MMMM") |> expect |> to(eql "August")
+        %DateTime{Momento.date! | month: 9} |> Momento.format("MMMM") |> expect |> to(eql "September")
+        %DateTime{Momento.date! | month: 10} |> Momento.format("MMMM") |> expect |> to(eql "October")
+        %DateTime{Momento.date! | month: 11} |> Momento.format("MMMM") |> expect |> to(eql "November")
+        %DateTime{Momento.date! | month: 12} |> Momento.format("MMMM") |> expect |> to(eql "December")
       end
 
       it "should replace the MMM token with the month abbreviation" do
+        %DateTime{Momento.date! | month: 1} |> Momento.format("MMM") |> expect |> to(eql "Jan")
+        %DateTime{Momento.date! | month: 2} |> Momento.format("MMM") |> expect |> to(eql "Feb")
+        %DateTime{Momento.date! | month: 3} |> Momento.format("MMM") |> expect |> to(eql "Mar")
+        %DateTime{Momento.date! | month: 4} |> Momento.format("MMM") |> expect |> to(eql "Apr")
+        %DateTime{Momento.date! | month: 5} |> Momento.format("MMM") |> expect |> to(eql "May")
         %DateTime{Momento.date! | month: 6} |> Momento.format("MMM") |> expect |> to(eql "Jun")
+        %DateTime{Momento.date! | month: 7} |> Momento.format("MMM") |> expect |> to(eql "Jul")
+        %DateTime{Momento.date! | month: 8} |> Momento.format("MMM") |> expect |> to(eql "Aug")
+        %DateTime{Momento.date! | month: 9} |> Momento.format("MMM") |> expect |> to(eql "Sep")
+        %DateTime{Momento.date! | month: 10} |> Momento.format("MMM") |> expect |> to(eql "Oct")
+        %DateTime{Momento.date! | month: 11} |> Momento.format("MMM") |> expect |> to(eql "Nov")
+        %DateTime{Momento.date! | month: 12} |> Momento.format("MMM") |> expect |> to(eql "Dec")        
       end
 
       it "should replace the MM token with two digit month of year padded with a zero" do

--- a/spec/format_spec.exs
+++ b/spec/format_spec.exs
@@ -24,8 +24,13 @@ defmodule FormatSpec do
         {:shared, datetime: %DateTime{Momento.date! | month: 5}}
       end
 
-      it "should replace the MMMM token with the full month name"
-      it "should replace the MMM token with the month abbreviation"
+      it "should replace the MMMM token with the full month name" do
+        shared.datetime |> Momento.format("MMMM") |> expect |> to(eql "May")
+      end
+
+      it "should replace the MMM token with the month abbreviation" do
+        %DateTime{Momento.date! | month: 6} |> Momento.format("MMM") |> expect |> to(eql "Jun")
+      end
 
       it "should replace the MM token with two digit month of year padded with a zero" do
         shared.datetime |> Momento.format("MM") |> expect |> to(eql "05")

--- a/spec/format_spec.exs
+++ b/spec/format_spec.exs
@@ -56,7 +56,14 @@ defmodule FormatSpec do
         shared.datetime |> Momento.format("DD") |> expect |> to(eql "05")
       end
 
-      it "should replace the Do token with day of month ordinal"
+      it "should replace the Do token with day of month ordinal" do
+        shared.datetime |> Momento.format("Do") |> expect |> to(eql "5th")
+        %DateTime{Momento.date! | day: 1} |> Momento.format("Do") |> expect |> to(eql "1st")
+        %DateTime{Momento.date! | day: 2} |> Momento.format("Do") |> expect |> to(eql "2nd")
+        %DateTime{Momento.date! | day: 3} |> Momento.format("Do") |> expect |> to(eql "3rd")
+        %DateTime{Momento.date! | day: 12} |> Momento.format("Do") |> expect |> to(eql "12th")
+        %DateTime{Momento.date! | day: 31} |> Momento.format("Do") |> expect |> to(eql "31st")
+      end
 
       it "should replace the D token with day of month without zero padding" do
         shared.datetime |> Momento.format("D") |> expect |> to(eql "5")


### PR DESCRIPTION
Implement format for tokens "MMMM" and "MM"
Had to change `String.replace` to use regex instead of string, since "MM" was also matching "MMMM" and causing undesired output. 
